### PR TITLE
Corrected error in Introduction.

### DIFF
--- a/coffeescript/01_introduction.html
+++ b/coffeescript/01_introduction.html
@@ -47,7 +47,7 @@
 
 <p>One of the easiest ways to initially play around with the library is to use it right inside the browser. Navigate to <a href="http://coffeescript.org">http://coffeescript.org</a> and click on the <em>Try CoffeeScript</em> tab. The site uses a browser version of the CoffeeScript compiler, converting any CoffeeScript typed inside the left panel to JavaScript in the right panel.</p>
 
-<p>You can also convert JavaScript back to CoffeeScript using the <a href="http://js2coffee.org/">js2coffee</a> project, especially useful when migration JavaScript projects to CoffeeScript.</p>
+<p>You can also convert JavaScript back to CoffeeScript using the <a href="http://js2coffee.org/">js2coffee</a> project, especially useful when migrating JavaScript projects to CoffeeScript.</p>
 
 <p>In fact, you can use the browser-based CoffeeScript compiler yourself, by including <a href="http://jashkenas.github.com/coffee-script/extras/coffee-script.js">this script</a> in a page, marking up any CoffeeScript script tags with the correct <code>type</code>.</p>
 

--- a/coffeescript/chapters/01_introduction.md
+++ b/coffeescript/chapters/01_introduction.md
@@ -24,7 +24,7 @@ CoffeeScript is not limited to the browser, and can be used to great effect in s
 
 One of the easiest ways to initially play around with the library is to use it right inside the browser. Navigate to [http://coffeescript.org](http://coffeescript.org) and click on the *Try CoffeeScript* tab. The site uses a browser version of the CoffeeScript compiler, converting any CoffeeScript typed inside the left panel to JavaScript in the right panel. 
 
-You can also convert JavaScript back to CoffeeScript using the [js2coffee](http://js2coffee.org/) project, especially useful when migration JavaScript projects to CoffeeScript.
+You can also convert JavaScript back to CoffeeScript using the [js2coffee](http://js2coffee.org/) project, especially useful when migrating JavaScript projects to CoffeeScript.
 
 In fact, you can use the browser-based CoffeeScript compiler yourself, by including [this script](http://jashkenas.github.com/coffee-script/extras/coffee-script.js) in a page, marking up any CoffeeScript script tags with the correct `type`.
 


### PR DESCRIPTION
Should have read  "especially useful when migrating JavaScript projects to CoffeeScript." instead of "especially useful when migration JavaScript projects to CoffeeScript."
