### PR TITLE
Remove wrong information about fat arrow notation

### DIFF
--- a/coffeescript/03_classes.html
+++ b/coffeescript/03_classes.html
@@ -76,26 +76,13 @@ alert "Animal is a #{animal.name}"
   price: 5
 
   sell: (customer) -&gt;
+    alert "Give me #{@price} shillings!"
 
 animal = new Animal
 animal.sell(new Customer)
 </code></pre>
 
-<p>Context changes are rife within JavaScript, and earlier in the Syntax chapter we talked about how CoffeeScript can lock the value of <code>this</code> to a particular context using a fat arrow function: <code>=&gt;</code>. This ensures that whatever context a function is called under, it'll always execute inside the context it was created in. CoffeeScript has extended support for fat arrows to classes, so by using a fat arrow for an instance method you'll ensure that it's invoked in the correct context, and that <code>this</code> is always equal to the current instance.</p>
-
-<p><span class="csscript"></span></p>
-
-<pre><code>class Animal
-  price: 5
-
-  sell: =&gt;
-    alert "Give me #{@price} shillings!"
-
-animal = new Animal
-$("#sell").click(animal.sell)
-</code></pre>
-
-<p>As demonstrated in the example above, this is especially useful in event callbacks. Normally the <code>sell()</code> function would be invoked in the context of the <code>#sell</code> element. However, by using fat arrows for <code>sell()</code>, we're ensuring the correct context is being maintained, and that <code>this.price</code> equals <code>5</code>.</p>
+<p>Context changes are rife within JavaScript, and earlier in the Syntax chapter we talked about how CoffeeScript can lock the value of <code>this</code> to a particular context using a fat arrow function: <code>=&gt;</code>. For functions inside a class definition, however, it doesn't matter whether you use <code>=&gt;</code> or <code>-&gt;</code> &mdash; CoffeeScript will generate exactly the same JavaScript.</p>
 
 <h2>Static properties</h2>
 


### PR DESCRIPTION
The fat arrow isn't needed for object methods, and in fact CoffeeScript will generate exactly the same code as with a thin arrow - see this part of the coffeescript code: https://github.com/jashkenas/coffee-script/blob/d687d52f9e36e093c73419d913c8cb6b1d062fd4/src/nodes.coffee#L1342
