### PR TITLE
Fixed error in "Syntax" -> "Object literals & array definition"

### DIFF
--- a/coffeescript/02_syntax.html
+++ b/coffeescript/02_syntax.html
@@ -190,7 +190,7 @@ object3 =
 User.create(name: "John Smith")
 </code></pre>
 
-<p>Likewise, arrays can use whitespace instead of comma separators, although the square brackets (<code>[]</code>) are still required.</p>
+<p>Likewise, arrays can use newline instead of comma separators, although the square brackets (<code>[]</code>) are still required.</p>
 
 <p><span class="csscript"></span></p>
 


### PR DESCRIPTION
The part "... arrays can use whitespace instead of comma separators ..." implies, that `a = [1 2 3]` also works, but it doesn't. Thus "whitespace" should be replaced by "newline".
