### PR TITLE
Regarding "Chapter 7 typo #47"

### DIFF
--- a/coffeescript/07_the_bad_parts.html
+++ b/coffeescript/07_the_bad_parts.html
@@ -491,7 +491,7 @@ parseInt('010', 10) is 10
   class window.Spine
 </code></pre>
 
-<p>Whilst I recommend enabling strict mode, but it's worth noting that strict mode doesn't enable any new features that aren't ready possible in JavaScript, and will actually slow down your code a bit by having the VM do more checks at runtime. You may want to develop with strict mode, and deploy to production without it.</p>
+<p>Whilst I recommend enabling strict mode, but it's worth noting that script mode doesn't enable any new features that aren't ready possible in JavaScript, and will actually slow down your code a bit by having the VM do more checks at runtime. You may want to develop with strict mode, and deploy to production without it.</p>
 
 <h2>JavaScript Lint</h2>
 

--- a/coffeescript/07_the_bad_parts.html
+++ b/coffeescript/07_the_bad_parts.html
@@ -491,7 +491,7 @@ parseInt('010', 10) is 10
   class window.Spine
 </code></pre>
 
-<p>Whilst I recommend enabling strict mode, but it's worth noting that script mode doesn't enable any new features that aren't ready possible in JavaScript, and will actually slow down your code a bit by having the VM do more checks at runtime. You may want to develop with strict mode, and deploy to production without it.</p>
+<p>Whilst I recommend enabling strict mode, but it's worth noting that strict mode doesn't enable any new features that aren't ready possible in JavaScript, and will actually slow down your code a bit by having the VM do more checks at runtime. You may want to develop with strict mode, and deploy to production without it.</p>
 
 <h2>JavaScript Lint</h2>
 

--- a/coffeescript/chapters/07_the_bad_parts.md
+++ b/coffeescript/chapters/07_the_bad_parts.md
@@ -162,7 +162,7 @@ Oddly enough in JavaScript, functions can be defined after they're used. For exa
     wem();
     function wem() {}
 
-The is because of function scope. Functions get hoisted before the programs execution and as such are available everywhere in the scope they were defined in, even if called before the actual definition in the source. The trouble is, hoisting behavior differs between browser; for example:
+This is because of function scope. Functions get hoisted before the programs execution and as such are available everywhere in the scope they were defined in, even if called before the actual definition in the source. The trouble is, hoisting behavior differs between browser; for example:
     
     if (true) {
       function declaration() {

--- a/coffeescript/chapters/07_the_bad_parts.md
+++ b/coffeescript/chapters/07_the_bad_parts.md
@@ -162,7 +162,7 @@ Oddly enough in JavaScript, functions can be defined after they're used. For exa
     wem();
     function wem() {}
 
-This is because of function scope. Functions get hoisted before the programs execution and as such are available everywhere in the scope they were defined in, even if called before the actual definition in the source. The trouble is, hoisting behavior differs between browser; for example:
+The is because of function scope. Functions get hoisted before the programs execution and as such are available everywhere in the scope they were defined in, even if called before the actual definition in the source. The trouble is, hoisting behavior differs between browser; for example:
     
     if (true) {
       function declaration() {


### PR DESCRIPTION
"The is because of function scope." changed to "This is because of function scope." in Chapter 7